### PR TITLE
Add support for custom HostnameVerifier with Secure Sockets

### DIFF
--- a/core/src/main/java/com/sun/mail/util/SocketFetcher.java
+++ b/core/src/main/java/com/sun/mail/util/SocketFetcher.java
@@ -20,6 +20,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.ConnectException;
@@ -47,6 +48,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.net.SocketFactory;
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
@@ -430,6 +432,54 @@ public class SocketFetcher {
 	return sf;
     }
 
+	/**
+	 * Return an instance of {@link HostnameVerifier}.
+	 * This method assumes the {@link HostnameVerifier} class provides an
+	 * accessible default constructor to instantiate the instance.
+	 *
+	 * @param hnvClassname               the class name of the {@link HostnameVerifier}.
+	 * @return                           the {@link HostnameVerifier}
+	 * @throws ClassNotFoundException    If the {@link HostnameVerifier} class cannot be found in the current class loader after also not being found in the context class loader.
+	 * @throws NoSuchMethodException     If the {@link HostnameVerifier} class does not implement a publicly accessible default constructor.
+	 * @throws InvocationTargetException
+	 * @throws InstantiationException
+	 * @throws IllegalAccessException
+	 */
+	private static HostnameVerifier getHostnameVerifier(String hnvClassname)
+			throws ClassNotFoundException,
+			NoSuchMethodException,
+			InvocationTargetException,
+			InstantiationException,
+			IllegalAccessException {
+		if (!(hnvClassname == null || hnvClassname.length() == 0)) {
+			ClassLoader ccl = getContextClassLoader();
+			Class<?> clsHostnameVerifier = null;
+
+			// Attempt to load the class from the context class loader.
+			if (ccl != null) {
+				try {
+					clsHostnameVerifier = Class.forName(hnvClassname, false, ccl);
+				} catch (ClassNotFoundException cex) {
+					// Ignore it - try the current class loader
+				}
+			}
+
+			// If the class was not resolved in the context class loader, try the current class loader.
+			if (clsHostnameVerifier == null) {
+				clsHostnameVerifier = Class.forName(hnvClassname);
+			}
+
+			// If we were able to resolve the class object, attempt to construct an instance
+			if (clsHostnameVerifier != null) {
+				// Attempt to invoke the default constructor
+				Constructor<?> defaultConstructor = clsHostnameVerifier.getConstructor();
+				return (HostnameVerifier) defaultConstructor.newInstance();
+			}
+		}
+
+		return null;
+	}
+
     /**
      * Start TLS on an existing socket.
      * Supports the "STARTTLS" command in many protocols.
@@ -629,7 +679,7 @@ public class SocketFetcher {
 	boolean idCheck = PropUtil.getBooleanProperty(props,
 			    prefix + ".ssl.checkserveridentity", false);
 	if (idCheck)
-	    checkServerIdentity(host, sslsocket);
+	    checkServerIdentity(props, prefix, host, sslsocket);
 	if (sf instanceof MailSSLSocketFactory) {
 	    MailSSLSocketFactory msf = (MailSSLSocketFactory)sf;
 	    if (!msf.isServerTrusted(host, sslsocket)) {
@@ -667,27 +717,54 @@ public class SocketFetcher {
      * Check the server from the Socket connection against the server name(s)
      * as expressed in the server certificate (RFC 2595 check).
      *
+	 * @param   props		the properties
+	 * @param   prefix		the property prefix
      * @param	server		name of the server expected
      * @param   sslSocket	SSLSocket connected to the server
      * @exception	IOException	if we can't verify identity of server
      */
-    private static void checkServerIdentity(String server, SSLSocket sslSocket)
+    private static void checkServerIdentity(Properties props, String prefix, String server, SSLSocket sslSocket)
 				throws IOException {
+	// Check using the defined hostname verifier instance, if present
+	Object hostnameVerifier = props.get(prefix + ".ssl.hostnameverifier");
+	if (hostnameVerifier == null) {
+		String hostnameVerifierClass = props.getProperty(prefix + ".ssl.hostnameverifier.class");
+		try {
+			hostnameVerifier = getHostnameVerifier(hostnameVerifierClass);
+		}
+		catch (Exception e) {
+			sslSocket.close();
+			IOException ioex = new IOException(
+					"Can't verify identity of server: " + server
+			);
+			ioex.initCause(e);
+			throw ioex;
+		}
+	}
 
-	// Check against the server name(s) as expressed in server certificate
-	try {
-	    java.security.cert.Certificate[] certChain =
-		      sslSocket.getSession().getPeerCertificates();
-	    if (certChain != null && certChain.length > 0 &&
-		    certChain[0] instanceof X509Certificate &&
-		    matchCert(server, (X509Certificate)certChain[0]))
-		return;
-	} catch (SSLPeerUnverifiedException e) {
-	    sslSocket.close();
-	    IOException ioex = new IOException(
-		"Can't verify identity of server: " + server);
-	    ioex.initCause(e);
-	    throw ioex;
+	// Use the defined HostnameVerifier, if present
+	if (hostnameVerifier != null) {
+		logger.finer("Using HostnameVerifier " + hostnameVerifier.getClass().getName());
+		HostnameVerifier hnv = (HostnameVerifier) hostnameVerifier;
+		if (hnv.verify(server, sslSocket.getSession()))
+			return;
+	}
+	else {
+		// Check against the server name(s) as expressed in server certificate
+		try {
+			java.security.cert.Certificate[] certChain =
+					sslSocket.getSession().getPeerCertificates();
+			if (certChain != null && certChain.length > 0 &&
+					certChain[0] instanceof X509Certificate &&
+					matchCert(server, (X509Certificate) certChain[0]))
+				return;
+		} catch (SSLPeerUnverifiedException e) {
+			sslSocket.close();
+			IOException ioex = new IOException(
+					"Can't verify identity of server: " + server);
+			ioex.initCause(e);
+			throw ioex;
+		}
 	}
 
 	// If we get here, there is nothing to consider the server as trusted.

--- a/providers/angus-mail/src/test/java/com/sun/mail/test/TestHostnameVerifier.java
+++ b/providers/angus-mail/src/test/java/com/sun/mail/test/TestHostnameVerifier.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.mail.test;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
+/**
+ * {@link HostnameVerifier} implementation intended to be used for unit tests.
+ */
+public class TestHostnameVerifier implements HostnameVerifier {
+    /*
+     * This is based on an assumption that the hostname verifier is instantiated
+     * by its default constructor in a managed way.
+     *
+     * Unit tests that check this property should impose their own thread safety.
+     * For example, when executing code expected to be using the TestHostnameVerifier,
+     * the unit test may synchronize on the TestHostnameVerifier class and call the
+     * static "reset" method prior to de-synchronizing.
+     */
+    public static int defaultConstructorCount = 0;
+    private boolean acceptConnections = true;
+    private boolean used = false;
+
+    public TestHostnameVerifier() {
+        defaultConstructorCount++;
+    }
+
+    public TestHostnameVerifier(boolean acceptConnections) {
+        this.acceptConnections = acceptConnections;
+    }
+
+    @Override
+    public boolean verify(String hostname, SSLSession session) {
+        used = true;
+        return acceptConnections;
+    }
+
+    /**
+     * Indicates whether the hostname verifier has been used.
+     * @return
+     */
+    public boolean hasBeenUsed() {
+        return used;
+    }
+
+    /**
+     * Used to reset static values.
+     */
+    public static void reset() {
+        defaultConstructorCount = 0;
+    }
+}

--- a/providers/angus-mail/src/test/java/com/sun/mail/util/SocketFetcherTest.java
+++ b/providers/angus-mail/src/test/java/com/sun/mail/util/SocketFetcherTest.java
@@ -22,16 +22,23 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Properties;
 
+import com.sun.mail.imap.IMAPHandler;
 import com.sun.mail.test.ProtocolHandler;
+import com.sun.mail.test.TestHostnameVerifier;
+import com.sun.mail.test.TestSSLSocketFactory;
 import com.sun.mail.test.TestServer;
 
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.junit.rules.Timeout;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import javax.net.ssl.HostnameVerifier;
+
+import static org.junit.Assert.*;
 
 /**
  * Test SocketFetcher.
@@ -41,6 +48,141 @@ public final class SocketFetcherTest {
     // timeout the test in case of deadlock
     @Rule
     public Timeout deadlockTimeout = Timeout.seconds(20);
+
+    @Test
+    public void testSSLSocketFactoryHostnameVerifierAcceptsConnections() throws Exception {
+        testSSLSocketFactoryHostnameVerifier(true);
+    }
+    /**
+     * Test connecting (IMAP) with SSL using a custom hostname verifier which will
+     * reject all connections.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSSLSocketFactoryHostnameVerifierRejectsConnections() throws Exception {
+        testSSLSocketFactoryHostnameVerifier(false);
+    }
+
+    @Test
+    public void testSSLSocketFactoryHostnameVerifierInstantiatedByString() throws Exception {
+        testSSLSocketFactoryHostnameVerifierByName();
+    }
+
+    /**
+     * Utility method for testing a custom {@link HostnameVerifier}.
+     *
+     * @param acceptConnections Whether the {@link HostnameVerifier} should accept or reject connections.
+     * @throws Exception
+     */
+    private void testSSLSocketFactoryHostnameVerifier(boolean acceptConnections) throws Exception {
+        final Properties properties = new Properties();
+        properties.setProperty("mail.imap.host", "localhost");
+        properties.setProperty("mail.imap.ssl.enable", "true");
+
+        TestSSLSocketFactory sf = new TestSSLSocketFactory();
+        properties.put("mail.imap.ssl.socketFactory", sf);
+
+        // don't fall back to non-SSL
+        properties.setProperty("mail.imap.socketFactory.fallback", "false");
+
+        TestHostnameVerifier hnv = new TestHostnameVerifier(acceptConnections);
+        properties.put("mail.imap.ssl.hostnameverifier", hnv);
+        properties.setProperty("mail.imap.ssl.checkserveridentity", "true"); // Required for hostname verification
+
+        ThrowingRunnable runnable = new ThrowingRunnable() {
+            @Override
+            public void run() throws Throwable {
+                TestServer server = null;
+                try {
+                    server = new TestServer(new IMAPHandler(), true);
+                    server.start();
+
+                    properties.setProperty("mail.imap.port", "" + server.getPort());
+                    final Session session = Session.getInstance(properties);
+
+                    final Store store = session.getStore("imap");
+                    store.connect("test", "test");
+                }
+                finally {
+                    if (server != null) {
+                        server.quit();
+                    }
+                }
+            }
+        };
+
+        if (!acceptConnections) {
+            // When the hostname verifier refuses a connection, a MessagingException will be thrown.
+            assertThrows(MessagingException.class, runnable);
+        }
+        else {
+            // When the hostname verifier is not set to refuse connections, no exception should be thrown.
+            synchronized (TestHostnameVerifier.class) {
+                try {
+                    runnable.run();
+                }
+                catch(Throwable t){
+                    fail("Unexpected exception thrown.");
+                }
+                finally{
+                    TestHostnameVerifier.reset();
+                }
+            }
+        }
+
+        // Ensure the custom hostname verifier was actually used.
+        assertTrue("Hostname verifier was not used.", hnv.hasBeenUsed());
+    }
+
+    private void testSSLSocketFactoryHostnameVerifierByName() throws Exception {
+        final Properties properties = new Properties();
+        properties.setProperty("mail.imap.host", "localhost");
+        properties.setProperty("mail.imap.ssl.enable", "true");
+
+        TestSSLSocketFactory sf = new TestSSLSocketFactory();
+        properties.put("mail.imap.ssl.socketFactory", sf);
+
+        // don't fall back to non-SSL
+        properties.setProperty("mail.imap.socketFactory.fallback", "false");
+
+        properties.setProperty("mail.imap.ssl.hostnameverifier.class", TestHostnameVerifier.class.getName());
+        properties.setProperty("mail.imap.ssl.checkserveridentity", "true"); // Required for hostname verification
+
+        ThrowingRunnable runnable = new ThrowingRunnable() {
+            @Override
+            public void run() throws Throwable {
+                TestServer server = null;
+                try {
+                    server = new TestServer(new IMAPHandler(), true);
+                    server.start();
+
+                    properties.setProperty("mail.imap.port", "" + server.getPort());
+                    final Session session = Session.getInstance(properties);
+
+                    final Store store = session.getStore("imap");
+                    store.connect("test", "test");
+                }
+                finally {
+                    if (server != null) {
+                        server.quit();
+                    }
+                }
+            }
+        };
+
+        synchronized (TestHostnameVerifier.class) {
+            try {
+                runnable.run();
+                assertEquals("Expected the Default Constructor of the HostnameVerifier class to be invoked once.", 1, TestHostnameVerifier.defaultConstructorCount);
+            } catch (Throwable t) {
+                fail("Unexpected exception thrown");
+            }
+            finally {
+                TestHostnameVerifier.reset();
+            }
+        }
+    }
 
     /**
      * Test connecting with proxy host and port.


### PR DESCRIPTION
This PR provides the migration of the original PR entered against the previous "mail" project: eclipse-ee4j/mail#566

> This PR is to provide the ability to utilize a custom HostnameVerifier implementation when using a secure socket for mail transport. This provides the ability for consumers of the API to use a pre-existing hostname verification implementation as opposed to performing additional, potentially redundant, error-prone property configuration.