### PR TITLE
org.eclipse.angus.mail bundle fails to resolve under OSGi due to mand…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -42,22 +42,4 @@
             <scope>runtime</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            javax.security.sasl;resolution:=optional,
-                            sun.security.util;resolution:=optional,
-                            *
-                        </Import-Package>
-                    </instructions>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/doc/release/CHANGES.txt
+++ b/doc/release/CHANGES.txt
@@ -7,6 +7,10 @@ for the Eclipse EE4J Angus Mail project:
 
     https://github.com/eclipse-ee4j/angus-mail/issues/<bug-number>
 
+          CHANGES IN THE 1.0.1 RELEASE
+          ----------------------------
+15: org.eclipse.angus.mail bundle fails to resolve under OSGi due to mandatory 'sun.security.util' package
+
           CHANGES IN THE 1.0.0 RELEASE
           ----------------------------
 The following bugs have been fixed in the 1.0.0 release.

--- a/pom.xml
+++ b/pom.xml
@@ -405,6 +405,11 @@
                     <instructions>
                         <_noextraheaders>true</_noextraheaders>
                         <DynamicImport-Package>*</DynamicImport-Package>
+                        <Import-Package>
+                            javax.security.sasl;resolution:=optional,
+                            sun.security.util;resolution:=optional,
+                            *
+                        </Import-Package>
                     </instructions>
                     <niceManifest>true</niceManifest>
                     <archive>

--- a/providers/pom.xml
+++ b/providers/pom.xml
@@ -53,24 +53,6 @@
         <module>jakarta.mail</module>
     </modules>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            javax.security.sasl;resolution:=optional,
-                            sun.security.util;resolution:=optional,
-                            *
-                        </Import-Package>
-                    </instructions>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <profiles>
         <!--
             This profile contains modules that should only be built


### PR DESCRIPTION
Relates to https://github.com/eclipse-ee4j/angus-mail/issues/15

This is how is the manifest before my fix:

```
Manifest-Version: 1.0
Bundle-Description: Angus Mail Provider
Bundle-DocURL: https://www.eclipse.org
Bundle-License: http://www.eclipse.org/legal/epl-2.0, https://www.gnu.or
 g/software/classpath/license.html, http://www.eclipse.org/org/documents
 /edl-v10.php
Bundle-ManifestVersion: 2
Bundle-Name: Angus Mail Provider
Bundle-SymbolicName: org.eclipse.angus.mail
Bundle-Vendor: Eclipse Foundation
Bundle-Version: 1.0.0.SNAPSHOT
Created-By: Apache Maven Bundle Plugin
DynamicImport-Package: *
Export-Package: com.sun.mail.auth;uses:="com.sun.mail.util,javax.securit
 y.auth.callback,javax.security.sasl";version="1.0.0",com.sun.mail.handl
 ers;uses:="jakarta.activation";version="1.0.0",com.sun.mail.iap;uses:="
 com.sun.mail.util";version="1.0.0",com.sun.mail.imap;uses:="com.sun.mai
 l.iap,com.sun.mail.imap.protocol,com.sun.mail.util,jakarta.activation,j
 akarta.mail,jakarta.mail.event,jakarta.mail.internet,jakarta.mail.searc
 h";version="1.0.0",com.sun.mail.imap.protocol;uses:="com.sun.mail.iap,c
 om.sun.mail.imap,com.sun.mail.util,jakarta.mail,jakarta.mail.internet,j
 akarta.mail.search";version="1.0.0",com.sun.mail.pop3;uses:="com.sun.ma
 il.util,jakarta.mail,jakarta.mail.internet";version="1.0.0",com.sun.mai
 l.smtp;uses:="com.sun.mail.util,jakarta.mail,jakarta.mail.internet";ver
 sion="1.0.0",com.sun.mail.util;uses:="jakarta.mail,jakarta.mail.util,ja
 vax.net.ssl";version="1.0.0",com.sun.mail.util.logging;uses:="jakarta.m
 ail";version="1.0.0"
Import-Package: com.sun.mail.auth;version="[1.0,2)",com.sun.mail.iap;ver
 sion="[1.0,2)",com.sun.mail.imap;version="[1.0,2)",com.sun.mail.imap.pr
 otocol;version="[1.0,2)",com.sun.mail.util;version="[1.0,2)",jakarta.ac
 tivation;version="[2.1,3)",jakarta.mail;version="[2.1,3)",jakarta.mail.
 event;version="[2.1,3)",jakarta.mail.internet;version="[2.1,3)",jakarta
 .mail.search;version="[2.1,3)",jakarta.mail.util;version="[2.1,3)",java
 x.crypto,javax.crypto.spec,javax.net,javax.net.ssl,javax.security.auth.
 callback,javax.security.auth.x500,javax.security.sasl,javax.xml.transfo
 rm,javax.xml.transform.stream,sun.security.util
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
```

This is with the fix:

```
Manifest-Version: 1.0
Bundle-Description: Angus Mail Provider
Bundle-DocURL: https://www.eclipse.org
Bundle-License: http://www.eclipse.org/legal/epl-2.0, https://www.gnu.or
 g/software/classpath/license.html, http://www.eclipse.org/org/documents
 /edl-v10.php
Bundle-ManifestVersion: 2
Bundle-Name: Angus Mail Provider
Bundle-SymbolicName: org.eclipse.angus.mail
Bundle-Vendor: Eclipse Foundation
Bundle-Version: 1.0.0.SNAPSHOT
Created-By: Apache Maven Bundle Plugin
DynamicImport-Package: *
Export-Package: com.sun.mail.auth;uses:="com.sun.mail.util,javax.securit
 y.auth.callback,javax.security.sasl";version="1.0.0",com.sun.mail.handl
 ers;uses:="jakarta.activation";version="1.0.0",com.sun.mail.iap;uses:="
 com.sun.mail.util";version="1.0.0",com.sun.mail.imap;uses:="com.sun.mai
 l.iap,com.sun.mail.imap.protocol,com.sun.mail.util,jakarta.activation,j
 akarta.mail,jakarta.mail.event,jakarta.mail.internet,jakarta.mail.searc
 h";version="1.0.0",com.sun.mail.imap.protocol;uses:="com.sun.mail.iap,c
 om.sun.mail.imap,com.sun.mail.util,jakarta.mail,jakarta.mail.internet,j
 akarta.mail.search";version="1.0.0",com.sun.mail.pop3;uses:="com.sun.ma
 il.util,jakarta.mail,jakarta.mail.internet";version="1.0.0",com.sun.mai
 l.smtp;uses:="com.sun.mail.util,jakarta.mail,jakarta.mail.internet";ver
 sion="1.0.0",com.sun.mail.util;uses:="jakarta.mail,jakarta.mail.util,ja
 vax.net.ssl";version="1.0.0",com.sun.mail.util.logging;uses:="jakarta.m
 ail";version="1.0.0"
Import-Package: com.sun.mail.auth;version="[1.0,2)",com.sun.mail.iap;ver
 sion="[1.0,2)",com.sun.mail.imap;version="[1.0,2)",com.sun.mail.imap.pr
 otocol;version="[1.0,2)",com.sun.mail.util;version="[1.0,2)",jakarta.ac
 tivation;version="[2.1,3)",jakarta.mail;version="[2.1,3)",jakarta.mail.
 event;version="[2.1,3)",jakarta.mail.internet;version="[2.1,3)",jakarta
 .mail.search;version="[2.1,3)",jakarta.mail.util;version="[2.1,3)",java
 x.crypto,javax.crypto.spec,javax.net,javax.net.ssl,javax.security.auth.
 callback,javax.security.auth.x500,javax.security.sasl;resolution:=optio
 nal,javax.xml.transform,javax.xml.transform.stream,sun.security.util;re
 solution:=optional
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"


```