### PR TITLE
Missing 'uses' in jakarta-mail bundle module-info #33 

### DIFF
--- a/dsn/pom.xml
+++ b/dsn/pom.xml
@@ -60,6 +60,7 @@
         <dependency>
             <groupId>org.eclipse.angus</groupId>
             <artifactId>angus-mail</artifactId>
+            <scope>provided</scope>
         </dependency>
 		<dependency>
 		    <groupId>junit</groupId>

--- a/providers/jakarta.mail/src/main/java/module-info.java
+++ b/providers/jakarta.mail/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -43,6 +43,7 @@ module jakarta.mail {
     exports com.sun.mail.util.logging;
 
     uses jakarta.mail.Provider;
+    uses jakarta.mail.util.StreamProvider;
 
     provides jakarta.mail.Provider with
             com.sun.mail.imap.IMAPProvider,


### PR DESCRIPTION
Relates to https://github.com/eclipse-ee4j/angus-mail/issues/33