### PR TITLE
#44: Documentation: SMTP, IMAP and POP3 Javadoc links lead to 404 page

### DIFF
--- a/www/IMAP-Store.md
+++ b/www/IMAP-Store.md
@@ -4,7 +4,7 @@ IMAP Store
 The IMAP Store supports reading mail from mail servers using the IMAP
 protocol. The primary documentation for the IMAP Store is in the
 javadocs for the
-[com.sun.mail.imap package](docs/api/com/sun/mail/imap/package-summary.html).
+[com.sun.mail.imap package](docs/api/com.sun.mail/com/sun/mail/imap/package-summary.html).
 Be sure to read the package level javadocs, which describe the
 properties you can set, as well as the javadocs for the individual
 classes in the package.

--- a/www/POP3-Store.md
+++ b/www/POP3-Store.md
@@ -4,7 +4,7 @@ POP3 Store
 The POP3 Store supports reading mail from mail servers using the POP3
 protocol. The primary documentation for the POP3 Store is in the
 javadocs for the
-[com.sun.mail.pop3 package](docs/api/com/sun/mail/pop3/package-summary.html).
+[com.sun.mail.pop3 package](docs/api/com.sun.mail/com/sun/mail/pop3/package-summary.html).
 Be sure to read the package level javadocs, which describe the
 properties you can set, as well as the javadocs for the individual
 classes in the package.

--- a/www/SMTP-Transport.md
+++ b/www/SMTP-Transport.md
@@ -4,7 +4,7 @@ SMTP Transport
 The only Transport (for sending mail) provided with Jakarta Mail uses the
 SMTP protocol. The primary documentation for the SMTP Transport is in
 the javadocs for the
-[com.sun.mail.smtp package](docs/api/com/sun/mail/smtp/package-summary.html).
+[com.sun.mail.smtp package](docs/api/com.sun.mail/com/sun/mail/smtp/package-summary.html).
 Be sure to read the package level javadocs, which describe the
 properties you can set, as well as the javadocs for the individual
 classes in the package.


### PR DESCRIPTION
fixes #44 