### PR TITLE
Inconsistent Java version requirements #76

### DIFF
--- a/doc/src/main/resources/README.md
+++ b/doc/src/main/resources/README.md
@@ -30,7 +30,7 @@ This project is part of [Eclipse Angus project](https://projects.eclipse.org/pro
 # <a name="Latest_News"></a>Latest News
 
 ## January 26, 2023 - Angus Mail 2.0.1 Final Release ##
-Fix wrong release 9 compilation of sources.
+A bug fix release of 2.0.0 fixing compatibility with Java SE 8.
 
 ## January 24, 2023 - Angus Mail 2.0.0 Final Release ##
 

--- a/doc/src/main/resources/README.md
+++ b/doc/src/main/resources/README.md
@@ -29,6 +29,9 @@ This project is part of [Eclipse Angus project](https://projects.eclipse.org/pro
 
 # <a name="Latest_News"></a>Latest News
 
+## January 26, 2023 - Angus Mail 2.0.1 Final Release ##
+Fix wrong release 9 compilation of sources.
+
 ## January 24, 2023 - Angus Mail 2.0.0 Final Release ##
 
 Changes `com.sun.mail` module name prefix

--- a/doc/src/main/resources/docs/CHANGES.txt
+++ b/doc/src/main/resources/docs/CHANGES.txt
@@ -7,6 +7,12 @@ for the Eclipse EE4J Angus Mail project:
 
     https://github.com/eclipse-ee4j/angus-mail/issues/<bug-number>
 
+          CHANGES IN THE 2.0.1 RELEASE
+          ----------------------------
+The following bugs have been fixed in the 2.0.1 release.
+
+76: Inconsistent Java version requirements
+
           CHANGES IN THE 2.0.0 RELEASE
           ----------------------------
 The following bugs have been fixed in the 2.0.0 release.

--- a/pom.xml
+++ b/pom.xml
@@ -499,7 +499,6 @@ Copyright &#169; 2019, ${current.year} Eclipse Foundation. All rights reserved.]
                             <goal>compile</goal>
                         </goals>
                         <configuration>
-                            <skipMain>${skip8}</skipMain>
                             <source>8</source>
                             <target>8</target>
                             <excludes>


### PR DESCRIPTION
https://github.com/eclipse-ee4j/angus-mail/issues/76

After compiling and unzipping it:

```
$ javap -verbose /home/jbescos/Downloads/jakarta.mail-2.0.1-SNAPSHOT/module-info.class | grep "major"
  major version: 53
$ javap -verbose /home/jbescos/Downloads/jakarta.mail-2.0.1-SNAPSHOT/jakarta/mail/BodyPart.class | grep "major"
  major version: 52
```
