### PR TITLE
WildFly support for MailHandler #110

### DIFF
--- a/doc/src/main/resources/docs/CHANGES.txt
+++ b/doc/src/main/resources/docs/CHANGES.txt
@@ -7,11 +7,17 @@ for the Eclipse EE4J Angus Mail project:
 
     https://github.com/eclipse-ee4j/angus-mail/issues/<bug-number>
 
+          CHANGES IN THE 2.0.3 RELEASE
+          ----------------------------
+The following bugs have been fixed in the 2.0.3 release.
+
+110: WildFly support for MailHandler
+
           CHANGES IN THE 2.0.2 RELEASE
           ----------------------------
 The following bugs have been fixed in the 2.0.2 release.
 
-83:  package-info.class major version: 53 
+83: package-info.class major version: 53 
 87: jakarta.mail fails to resolve due to required org.glassfish.hk2.osgiresourcelocator dependency
 88: Fix Provide-Capability headers in MANIFEST.MF (required by OSGi service loader).
 89: fix default build without -Poss-release

--- a/doc/src/main/resources/docs/COMPAT.txt
+++ b/doc/src/main/resources/docs/COMPAT.txt
@@ -4,6 +4,17 @@
 		    Angus Mail ${angus-mail.version} release
 		    ------------------------------
 
+-- Angus Mail 2.0.3 --
+
+- MailHandler public methods no longer hostile to invalid arguments
+
+    Public methods that are contractually owned by MailHandler are no longer
+    hostile to invalid input such as zero and null.  When invalid or out of
+    range values are used the MailHandler will use the same default that the
+    LogManager would have chosen during creation.  This allows bean style
+    configurators to remove properties from the MailHandler without knowing the
+    valid defaults for each property.
+
 -- Angus Mail 2.0.0 --
 
 - Java package and java module names changed

--- a/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/CompactFormatter.java
+++ b/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/CompactFormatter.java
@@ -263,12 +263,9 @@ public class CompactFormatter extends java.util.logging.Formatter {
             msg = record.getMessage();
         }
 
-        msg = replaceClassName(msg, record.getThrown());
-
         //Render any String.format patterns in the message.
         final Object[] params = record.getParameters();
         if (params != null && params.length != 0) {
-            msg = replaceClassName(msg, params);
             Locale l = getLocale(record);
             try {
                 if (l == null) { //BUG ID 6282094
@@ -278,7 +275,9 @@ public class CompactFormatter extends java.util.logging.Formatter {
                 }
             } catch (RuntimeException ignore) {
             }
+            msg = replaceClassName(msg, params);
         }
+        msg = replaceClassName(msg, record.getThrown());
         return msg;
     }
 

--- a/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/CompactFormatter.java
+++ b/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/CompactFormatter.java
@@ -265,7 +265,8 @@ public class CompactFormatter extends java.util.logging.Formatter {
 
         //Render any String.format patterns in the message.
         final Object[] params = record.getParameters();
-        if (params != null && params.length != 0 && msg != null) {
+        if (msg != null && ((params != null && params.length != 0)
+                || msg.contains("%n"))) {
             Locale l = getLocale(record);
             try {
                 if (l == null) { //BUG ID 6282094

--- a/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/CompactFormatter.java
+++ b/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/CompactFormatter.java
@@ -265,7 +265,7 @@ public class CompactFormatter extends java.util.logging.Formatter {
 
         //Render any String.format patterns in the message.
         final Object[] params = record.getParameters();
-        if (params != null && params.length != 0) {
+        if (params != null && params.length != 0 && msg != null) {
             Locale l = getLocale(record);
             try {
                 if (l == null) { //BUG ID 6282094

--- a/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/DurationFilter.java
+++ b/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/DurationFilter.java
@@ -349,7 +349,7 @@ public class DurationFilter implements Filter {
             }
 
             //Under the rate if the count has not been reached.
-            if (count != records) {
+            if ((records - count) > 0L) {
                 ++count;
                 allow = true;
             } else {

--- a/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/MailHandler.java
+++ b/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/MailHandler.java
@@ -1919,7 +1919,9 @@ public class MailHandler extends Handler {
     }
 
     /**
-     * Calls log manager checkAccess if this is sealed.
+     * Checks logging permissions if this handler has been sealed.
+     * @throws SecurityException if a security manager exists and the caller
+     *                           does not have {@code LoggingPermission("control")}.
      */
     private void checkAccess() {
         if (sealed) {
@@ -4602,18 +4604,6 @@ public class MailHandler extends Handler {
      */
     private static RuntimeException attachmentMismatch(final String msg) {
         return new IndexOutOfBoundsException(msg);
-    }
-
-    /**
-     * Outline the attachment mismatch message. See Bug ID 6533165.
-     *
-     * @param expected the expected array length.
-     * @param found    the array length that was given.
-     * @return a RuntimeException populated with a message.
-     */
-    private static RuntimeException attachmentMismatch(int expected, int found) {
-        return attachmentMismatch("Attachments mismatched, expected "
-                + expected + " but given " + found + '.');
     }
 
     /**

--- a/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/MailHandler.java
+++ b/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/MailHandler.java
@@ -593,9 +593,6 @@ public class MailHandler extends Handler {
     public MailHandler(final int capacity) {
         init((Properties) null);
         sealed = true;
-        if (capacity <=0 ) {
-           throw new IllegalArgumentException();
-        }
         setCapacity0(capacity);
     }
 
@@ -605,15 +602,11 @@ public class MailHandler extends Handler {
      * documentation.  This <code>Handler</code> will also search the
      * <code>LogManager</code> for defaults if needed.
      *
-     * @param props a non <code>null</code> properties object.
-     * @throws NullPointerException if <code>props</code> is <code>null</code>.
+     * @param props a properties object or null.
      * @throws SecurityException    if a security manager exists and the
      *                              caller does not have <code>LoggingPermission("control")</code>.
      */
-    public MailHandler(final Properties props) {
-        if (props == null) {
-            throw new NullPointerException();
-        }
+    public MailHandler(Properties props) {
         init(props);
         sealed = true;
         setMailProperties0(props);

--- a/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/MailHandler.java
+++ b/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/MailHandler.java
@@ -1713,7 +1713,8 @@ public class MailHandler extends Handler {
             this.alignAttachmentFormatters(formatters.length);
             this.alignAttachmentFilters(formatters.length);
             for (int i = 0; i < formatters.length; ++i) {
-                String name = names != null ? names[i] : null;
+                //names is non-null if formatters length is not zero
+                String name = names[i];
                 if (isEmpty(name)) {
                     name = toString(this.attachmentFormatters[i]);
                 }

--- a/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/MailHandler.java
+++ b/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/MailHandler.java
@@ -1713,7 +1713,7 @@ public class MailHandler extends Handler {
             this.alignAttachmentFormatters(formatters.length);
             this.alignAttachmentFilters(formatters.length);
             for (int i = 0; i < formatters.length; ++i) {
-                String name = names[i];
+                String name = names != null ? names[i] : null;
                 if (isEmpty(name)) {
                     name = toString(this.attachmentFormatters[i]);
                 }

--- a/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/SeverityComparator.java
+++ b/mailhandler/src/main/java/org/eclipse/angus/mail/util/logging/SeverityComparator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023 Jason Mehrens. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -235,9 +236,9 @@ public class SeverityComparator implements Comparator<LogRecord>, Serializable {
         if (cmp == 0) {
             cmp = applyThenCompare(o1.getThrown(), o2.getThrown());
             if (cmp == 0) {
-                cmp = compare(o1.getSequenceNumber(), o2.getSequenceNumber());
+                cmp = Long.compare(o1.getSequenceNumber(), o2.getSequenceNumber());
                 if (cmp == 0) {
-                    cmp = compare(o1.getMillis(), o2.getMillis());
+                    cmp = Long.compare(o1.getMillis(), o2.getMillis());
                 }
             }
         }
@@ -312,7 +313,7 @@ public class SeverityComparator implements Comparator<LogRecord>, Serializable {
      * argument is less than, equal to, or greater than the second.
      */
     private int compare(final Level a, final Level b) {
-        return a == b ? 0 : compare(a.intValue(), b.intValue());
+        return a == b ? 0 : Integer.compare(a.intValue(), b.intValue());
     }
 
     /**
@@ -324,17 +325,5 @@ public class SeverityComparator implements Comparator<LogRecord>, Serializable {
      */
     private static String toString(final Object o1, final Object o2) {
         return o1 + ", " + o2;
-    }
-
-    /**
-     * Compare two longs. Can be removed when JDK 1.7 is required.
-     *
-     * @param x the first long.
-     * @param y the second long.
-     * @return a negative integer, zero, or a positive integer as the first
-     * argument is less than, equal to, or greater than the second.
-     */
-    private int compare(final long x, final long y) {
-        return x < y ? -1 : x > y ? 1 : 0;
     }
 }

--- a/providers/angus-mail/src/test/java/org/eclipse/angus/mail/util/logging/CollectorFormatterTest.java
+++ b/providers/angus-mail/src/test/java/org/eclipse/angus/mail/util/logging/CollectorFormatterTest.java
@@ -631,6 +631,35 @@ public class CollectorFormatterTest extends AbstractLogging {
     }
 
     @Test
+    public void testGetSetFormat() {
+        CollectorFormatter cf = new CollectorFormatter();
+        final String init = cf.getFormat();
+        String pattern = "foo";
+        assertNotEquals(pattern, cf.getFormat());
+        cf.setFormat(pattern);
+        assertEquals(pattern, cf.getFormat());
+        LogRecord r = new LogRecord(Level.SEVERE, "bar");
+        cf.format(r);
+        assertEquals(pattern, cf.toString());
+
+        cf.setFormat((String) null);
+        assertEquals(init, cf.getFormat());
+    }
+
+    @Test
+    public void testGetSetFormatter() {
+        CollectorFormatter cf = new CollectorFormatter();
+        final Formatter init = cf.getFormatter();
+        Formatter target = new XMLFormatter();
+        assertNotEquals(target, cf.getFormatter());
+        cf.setFormatter(target);
+        assertEquals(target, cf.getFormatter());
+
+        cf.setFormatter((Formatter) null);
+        assertEquals(init.getClass(), cf.getFormatter().getClass());
+    }
+
+    @Test
     public void testGetTail() {
         CollectorFormatter f = new CollectorFormatter(
                 "{0}{1}{2}{3}{4}{5}{6}{7}{8}{9}{10}{11}{12}{13}",
@@ -987,6 +1016,17 @@ public class CollectorFormatterTest extends AbstractLogging {
     @Test
     public void testComparatorEmpty() throws Exception {
         testComparatorNullOrEmpty("");
+    }
+
+    @Test
+    public void testComparatorGetSet() {
+        CollectorFormatter cf = new CollectorFormatter();
+        assertEquals(SeverityComparator.getInstance(), cf.getComparator());
+        cf.setComparator((Comparator<LogRecord>) null);
+        assertNull(cf.getComparator());
+
+        cf.setComparator(SeverityComparator.getInstance());
+        assertEquals(SeverityComparator.getInstance(), cf.getComparator());
     }
 
     @Test(expected = ClassCastException.class)

--- a/providers/angus-mail/src/test/java/org/eclipse/angus/mail/util/logging/CompactFormatterTest.java
+++ b/providers/angus-mail/src/test/java/org/eclipse/angus/mail/util/logging/CompactFormatterTest.java
@@ -770,6 +770,14 @@ public class CompactFormatterTest extends AbstractLogging {
     }
 
     @Test
+    public void testFormatMessageWithNullMessage() {
+        CompactFormatter cf = new CompactFormatter();
+        LogRecord r = new LogRecord(Level.INFO, (String) null);
+        r.setParameters(new Object[]{null, null});
+        assertNull(cf.formatMessage(r));
+    }
+
+    @Test
     public void testFormatMessageLocale() throws Exception {
         String msg = "message";
         CompactFormatter cf = new CompactFormatter("%5$s");

--- a/providers/angus-mail/src/test/java/org/eclipse/angus/mail/util/logging/CompactFormatterTest.java
+++ b/providers/angus-mail/src/test/java/org/eclipse/angus/mail/util/logging/CompactFormatterTest.java
@@ -178,6 +178,21 @@ public class CompactFormatterTest extends AbstractLogging {
     }
 
     @Test
+    public void testGetSetFormat() {
+        CompactFormatter cf = new CompactFormatter();
+        final String init = cf.getFormat();
+        String pattern = "foo";
+        assertNotEquals(pattern, cf.getFormat());
+        cf.setFormat(pattern);
+        assertEquals(pattern, cf.getFormat());
+        LogRecord r = new LogRecord(Level.SEVERE, "bar");
+        assertEquals(pattern, cf.format(r));
+
+        cf.setFormat((String) null);
+        assertEquals(init, cf.getFormat());
+    }
+
+    @Test
     public void testFormat() throws Exception {
         final String p = CompactFormatter.class.getName();
         Properties props = new Properties();

--- a/providers/angus-mail/src/test/java/org/eclipse/angus/mail/util/logging/DurationFilterTest.java
+++ b/providers/angus-mail/src/test/java/org/eclipse/angus/mail/util/logging/DurationFilterTest.java
@@ -650,6 +650,19 @@ public class DurationFilterTest extends AbstractLogging {
     }
 
     @Test
+    public void testCountExceedsRecords() {
+        DurationFilter one = new DurationFilter(10L, 15L * 60L * 1000L);
+        LogRecord r = new LogRecord(Level.INFO, "");
+        final long now = r.getMillis();
+        for (long i = 1L; i <= one.getRecords() / 2L; ++i) {
+            assertTrue(one.isLoggable(r));
+            setEpochMilli(r, now + i);
+        }
+        one.setRecords(1L);
+        assertFalse(one.isLoggable(r));
+    }
+
+    @Test
     public void testDurationMillis() {
         DurationFilter one = new DurationFilter();
         DurationFilter two = new DurationFilter();

--- a/providers/angus-mail/src/test/java/org/eclipse/angus/mail/util/logging/DurationFilterTest.java
+++ b/providers/angus-mail/src/test/java/org/eclipse/angus/mail/util/logging/DurationFilterTest.java
@@ -36,6 +36,7 @@ import java.util.logging.Logger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -624,6 +625,51 @@ public class DurationFilterTest extends AbstractLogging {
         assertTrue(s.contains("duration="));
         assertTrue(s.contains("idle="));
         assertTrue(s.contains("loggable="));
+    }
+
+    @Test
+    public void testRecords() {
+        DurationFilter one = new DurationFilter();
+        DurationFilter two = new DurationFilter();
+        final long records = 1000L;
+        assertEquals(records, one.getRecords());
+        assertEquals(records, two.getRecords());
+        assertEquals(one, two);
+
+        one.setRecords(1L);
+        assertEquals(1L, one.getRecords());
+        assertNotEquals(one, two);
+
+        two.setRecords(one.getRecords());
+        assertEquals(one, two);
+
+        one.setRecords(-1L);
+        assertEquals(records, one.getRecords());
+        one.setRecords(0L);
+        assertEquals(records, one.getRecords());
+    }
+
+    @Test
+    public void testDurationMillis() {
+        DurationFilter one = new DurationFilter();
+        DurationFilter two = new DurationFilter();
+        final long duration = 15L * 60L * 1000L;
+        assertEquals(duration, one.getDurationMillis());
+        assertEquals(duration, two.getDurationMillis());
+        assertEquals(one, two);
+
+        one.setDurationMillis(1L);
+        assertEquals(1L, one.getDurationMillis());
+        assertNotEquals(one, two);
+
+        two.setDurationMillis(one.getDurationMillis());
+        assertEquals(one, two);
+
+        one.setDurationMillis(-1L);
+        assertEquals(duration, one.getDurationMillis());
+
+        one.setDurationMillis(0L);
+        assertEquals(duration, one.getDurationMillis());
     }
 
     @Test

--- a/providers/angus-mail/src/test/java/org/eclipse/angus/mail/util/logging/MailHandlerTest.java
+++ b/providers/angus-mail/src/test/java/org/eclipse/angus/mail/util/logging/MailHandlerTest.java
@@ -3726,6 +3726,33 @@ public class MailHandlerTest extends AbstractLogging {
     }
 
     @Test
+    public void testAuthentication() {
+        MailHandler instance = new MailHandler(createInitProperties(""));
+        InternalErrorManager em = new InternalErrorManager();
+        instance.setErrorManager(em);
+
+        instance.setAuthentication((String) null);
+        assertNull(instance.getAuthenticator());
+
+        instance.setAuthentication(EmptyAuthenticator.class.getName());
+        assertEquals(EmptyAuthenticator.class,
+                instance.getAuthenticator().getClass());
+
+        instance.setAuthentication("");
+        assertTrue(instance.getAuthenticator().getClass().getName()
+                .contains("DefaultAuthenticator"));
+
+        instance.setAuthentication("foo");
+        assertTrue(instance.getAuthenticator().getClass().getName()
+                .contains("DefaultAuthenticator"));
+
+        for (Exception t : em.exceptions) {
+            dump(t);
+        }
+        assertTrue(em.exceptions.isEmpty());
+    }
+
+    @Test
     public void testAuthenticator_Authenticator_Arg() {
         Authenticator auth = new EmptyAuthenticator();
 

--- a/providers/angus-mail/src/test/java/org/eclipse/angus/mail/util/logging/MailHandlerTest.java
+++ b/providers/angus-mail/src/test/java/org/eclipse/angus/mail/util/logging/MailHandlerTest.java
@@ -3639,30 +3639,22 @@ public class MailHandlerTest extends AbstractLogging {
 
     @Test
     public void testCapacity() {
-        try {
-            MailHandler h = new MailHandler(-1);
-            h.getCapacity();
-            fail("Negative capacity was allowed.");
-        } catch (IllegalArgumentException pass) {
-        } catch (RuntimeException RE) {
-            fail(RE.toString());
-        }
+        MailHandler h = new MailHandler(-1);
+        assertEquals(1000, h.getCapacity());
 
-        try {
-            MailHandler h = new MailHandler(0);
-            h.getCapacity();
-            fail("Zero capacity was allowed.");
-        } catch (IllegalArgumentException pass) {
-        } catch (RuntimeException RE) {
-            fail(RE.toString());
-        }
+        h = new MailHandler(0);
+        assertEquals(1000, h.getCapacity());
 
-        try {
-            MailHandler h = new MailHandler(1);
-            h.getCapacity();
-        } catch (RuntimeException RE) {
-            fail(RE.toString());
-        }
+        h = new MailHandler(1);
+        assertEquals(1, h.getCapacity());
+
+        h.setCapacity(10);
+        assertEquals(10, h.getCapacity());
+        h.close();
+        assertEquals(10, h.getCapacity());
+
+        h.setCapacity(1000);
+        assertEquals(1000, h.getCapacity());
 
         final int expResult = 20;
         MailHandler instance = new MailHandler(20);

--- a/providers/angus-mail/src/test/java/org/eclipse/angus/mail/util/logging/MailHandlerTest.java
+++ b/providers/angus-mail/src/test/java/org/eclipse/angus/mail/util/logging/MailHandlerTest.java
@@ -2366,6 +2366,109 @@ public class MailHandlerTest extends AbstractLogging {
     }
 
     @Test
+    public void testEnabled() {
+        MailHandler instance = new MailHandler(createInitProperties(""));
+        InternalErrorManager em = new InternalErrorManager();
+        instance.setErrorManager(em);
+
+        assertEquals(true, instance.isEnabled());
+        final Level[] lvls = getAllLevels();
+        for (Level lvl : lvls) {
+            instance.setEnabled(false);
+            instance.setLevel(lvl);
+            assertEquals(Level.OFF, instance.getLevel());
+            assertEquals(false, instance.isEnabled());
+
+            instance.setEnabled(true);
+            assertEquals(instance.getLevel(), lvl);
+
+            //2nd enable must not produce a null level.
+            instance.setEnabled(true);
+            assertEquals(instance.getLevel(), lvl);
+
+            //2nd disable must not produce OFF on re-enable.
+            if (!Level.OFF.equals(lvl)) {
+                instance.setEnabled(false);
+                instance.setEnabled(false);
+                instance.setEnabled(true);
+                assertEquals(instance.getLevel(), lvl);
+            }
+
+        }
+
+        instance.setLevel(Level.WARNING);
+        instance.close();
+        assertEquals(Level.OFF, instance.getLevel());
+        assertEquals(false, instance.isEnabled());
+        for (Level lvl : lvls) {
+            instance.setLevel(lvl);
+            assertEquals(Level.OFF, instance.getLevel());
+            assertEquals(false, instance.isEnabled());
+
+            instance.setEnabled(true);
+            assertEquals(false, instance.isEnabled());
+            assertEquals(Level.OFF, instance.getLevel());
+
+            instance.setEnabled(false);
+            assertEquals(false, instance.isEnabled());
+            assertEquals(Level.OFF, instance.getLevel());
+        }
+        assertEquals(true, em.exceptions.isEmpty());
+    }
+
+    @Test
+    public void testInitEnabled() throws Exception {
+        LogManager manager = LogManager.getLogManager();
+        try {
+            manager.reset();
+
+            final String p = MailHandler.class.getName();
+            Properties props = createInitProperties(p);
+            props.put(p.concat(".enabled"), "false");
+            read(manager, props);
+
+            MailHandler instance = new MailHandler();
+            InternalErrorManager em = internalErrorManagerFrom(instance);
+
+            assertEquals(InternalErrorManager.class, em.getClass());
+            assertFalse(instance.isEnabled());
+            assertEquals(Level.OFF, instance.getLevel());
+            instance.setEnabled(true);
+            assertEquals(Level.WARNING, instance.getLevel());
+            assertTrue(instance.isEnabled());
+
+            for (Exception exception : em.exceptions) {
+                dump(exception);
+            }
+            instance.close();
+            assertTrue(em.exceptions.isEmpty());
+
+            for (String v : new String[]{"true", null, "", "null"}) {
+                if (v != null) {
+                    props.put(p.concat(".enabled"), v);
+                } else {
+                    props.remove(p.concat(".enabled"));
+                }
+
+                read(manager, props);
+
+                instance = new MailHandler();
+                em = internalErrorManagerFrom(instance);
+                assertTrue(instance.isEnabled());
+                assertEquals(Level.WARNING, instance.getLevel());
+
+                for (Exception exception : em.exceptions) {
+                    dump(exception);
+                }
+                instance.close();
+                assertTrue(em.exceptions.isEmpty());
+            }
+        } finally {
+            manager.reset();
+        }
+    }
+
+    @Test
     public void testLevel() {
         MailHandler instance = new MailHandler(createInitProperties(""));
         InternalErrorManager em = new InternalErrorManager();
@@ -2636,14 +2739,8 @@ public class MailHandlerTest extends AbstractLogging {
         instance.setErrorManager(em);
 
         assertNotNull(instance.getPushLevel());
-
-        try {
-            instance.setPushLevel((Level) null);
-            fail("Null level was allowed");
-        } catch (NullPointerException pass) {
-        } catch (RuntimeException re) {
-            fail(re.toString());
-        }
+        instance.setPushLevel((Level) null);
+        assertEquals(Level.OFF, instance.getPushLevel());
 
         final Level[] lvls = getAllLevels();
         for (Level lvl : lvls) {
@@ -3740,13 +3837,9 @@ public class MailHandlerTest extends AbstractLogging {
         assertNotNull(instance.getMailProperties());
         assertEquals(Properties.class, instance.getMailProperties().getClass());
 
-        try {
-            instance.setMailProperties((Properties) null);
-            fail("Null was allowed.");
-        } catch (NullPointerException pass) {
-        } catch (RuntimeException RE) {
-            fail(RE.toString());
-        }
+
+        instance.setMailProperties((Properties) null);
+        assertTrue(instance.getMailProperties().isEmpty());
 
         instance.setMailProperties(props);
         Properties stored = instance.getMailProperties();
@@ -3799,6 +3892,90 @@ public class MailHandlerTest extends AbstractLogging {
         }
         assertEquals(0, failed);
         assertFalse(em.exceptions.isEmpty());
+    }
+
+
+    @Test
+    public void testMailEntries() throws Exception {
+        Properties props = new Properties();
+        MailHandler instance = new MailHandler();
+        InternalErrorManager em = new InternalErrorManager();
+        instance.setErrorManager(em);
+
+        assertNotNull(instance.getMailProperties());
+        assertEquals(Properties.class, instance.getMailProperties().getClass());
+
+        instance.setMailEntries(
+                "mail.from=localhost@localdomain\n"
+                + "mail.to=remotehost@remotedomain#!"
+                + "mail.host=localhost#!"
+                + "mail.user=mailuser");
+
+        Properties stored = instance.getMailProperties();
+
+        assertNotNull(stored);
+        assertNotSame(props, stored);
+        assertEquals(props.getClass(), stored.getClass());
+
+        assertEquals(true, em.exceptions.isEmpty());
+        assertEquals("localhost@localdomain", stored.getProperty("mail.from"));
+        assertEquals("remotehost@remotedomain", stored.getProperty("mail.to"));
+        assertEquals("localhost", stored.getProperty("mail.host"));
+        assertEquals("mailuser", stored.getProperty("mail.user"));
+
+        assertEquals(false, stored.isEmpty());
+        instance.setMailEntries((String) null);
+        assertEquals(true, instance.getMailProperties().isEmpty());
+
+        instance.setMailEntries(
+                "mail.from:localhost@localdomain\n"
+                + "mail.to:remotehost@remotedomain#!"
+                + "mail.host:localhost#!"
+                + "mail.user:remoteuser");
+        stored = instance.getMailProperties();
+
+        //Ensure properties are not cleared.
+        assertEquals("localhost@localdomain", stored.getProperty("mail.from"));
+        assertEquals("remotehost@remotedomain", stored.getProperty("mail.to"));
+        assertEquals("localhost", stored.getProperty("mail.host"));
+        assertEquals("remoteuser", stored.getProperty("mail.user"));
+
+        instance.setMailEntries(""); //Clears all properties
+        assertEquals(true, instance.getMailProperties().isEmpty());
+
+        instance.setMailProperties(stored);
+        assertEquals(false, instance.getMailProperties().isEmpty());
+
+        instance.setMailEntries("null"); //null literal is treated as empty
+        assertEquals(true, instance.getMailProperties().isEmpty());
+
+        instance.setMailProperties(stored);
+        assertEquals(false, stored.isEmpty());
+        instance.setMailEntries("mail.user"); //key with empty value
+        stored = instance.getMailProperties();
+
+        //Ensure properties are not cleared.
+        assertEquals(1, stored.size());
+        assertEquals("", stored.getProperty("mail.user"));
+
+        final String test = "test\u03b1";
+        final String saddr = test + '@' + UNKNOWN_HOST;
+        instance.setMailEntries("mail.user="+ saddr
+                + "#!mail.mime.allowutf8=true");
+
+        stored = instance.getMailProperties();
+        assertEquals("true", stored.getProperty("mail.mime.allowutf8"));
+        assertEquals(saddr, stored.getProperty("mail.user"));
+
+        instance.setMailEntries(instance.getMailEntries());
+        assertEquals(stored, instance.getMailProperties());
+
+        instance.close();
+
+        for (Exception exception : em.exceptions) {
+            dump(exception);
+        }
+        assertTrue(em.exceptions.isEmpty());
     }
 
     @Test
@@ -4003,13 +4180,10 @@ public class MailHandlerTest extends AbstractLogging {
             instance.setAttachmentFormatters();
         }
 
-        try {
-            instance.setAttachmentFilters((Filter[]) null);
-            fail("Null allowed.");
-        } catch (NullPointerException pass) {
-        } catch (RuntimeException re) {
-            fail(re.toString());
-        }
+
+        instance.setAttachmentFilters((Filter[]) null);
+        assertEquals(instance.getAttachmentFilters().length, 0);
+
 
         try {
             instance.setAttachmentFilters();
@@ -4017,28 +4191,21 @@ public class MailHandlerTest extends AbstractLogging {
             fail(re.toString());
         }
 
-        try {
-            assertEquals(0, instance.getAttachmentFormatters().length);
-
-            instance.setAttachmentFilters(BooleanFilter.TRUE);
-            fail("Filter to formatter mismatch.");
-        } catch (IndexOutOfBoundsException pass) {
-        } catch (RuntimeException re) {
-            fail(re.toString());
-        }
+        assertEquals(0, instance.getAttachmentFormatters().length);
+        instance.setAttachmentFilters(BooleanFilter.TRUE);
+        assertEquals(1, instance.getAttachmentFormatters().length);
 
         instance.setAttachmentFormatters(
                 new SimpleFormatter(), new XMLFormatter());
 
-        try {
-            assertEquals(2, instance.getAttachmentFormatters().length);
+        assertEquals(2, instance.getAttachmentFormatters().length);
 
-            instance.setAttachmentFilters(BooleanFilter.TRUE);
-            fail("Filter to formatter mismatch.");
-        } catch (IndexOutOfBoundsException pass) {
-        } catch (RuntimeException re) {
-            fail(re.toString());
-        }
+        instance.setAttachmentFilters(BooleanFilter.TRUE);
+        assertEquals(1, instance.getAttachmentFormatters().length);
+
+        instance.setAttachmentFormatters(
+                new SimpleFormatter(), new XMLFormatter());
+
 
         try {
             assertEquals(2, instance.getAttachmentFormatters().length);
@@ -4059,15 +4226,12 @@ public class MailHandlerTest extends AbstractLogging {
             fail(re.toString());
         }
 
-        try {
-            assertEquals(2, instance.getAttachmentFormatters().length);
-            instance.setAttachmentFilters();
-            fail("Filter to formatter mismatch.");
-        } catch (IndexOutOfBoundsException pass) {
-        } catch (RuntimeException re) {
-            fail(re.toString());
-        }
+        assertEquals(2, instance.getAttachmentFormatters().length);
+        instance.setAttachmentFilters();
+        assertEquals(0, instance.getAttachmentFormatters().length);
 
+        instance.setAttachmentFormatters(
+                new SimpleFormatter(), new XMLFormatter());
         try {
             assertEquals(instance.getAttachmentFormatters().length, 2);
             Filter[] filters = new Filter[]{null, null};
@@ -4143,22 +4307,17 @@ public class MailHandlerTest extends AbstractLogging {
         assertEquals(result[0].getClass(),
                 instance.getAttachmentFormatters()[1].getClass());
 
-        try {
-            instance.setAttachmentFormatters((Formatter[]) null);
-            fail("Null was allowed.");
-        } catch (NullPointerException NPE) {
-        } catch (RuntimeException re) {
-            fail(re.toString());
-        }
+
+        instance.setAttachmentFormatters((Formatter[]) null);
+        assertEquals(0, instance.getAttachmentFormatters().length);
 
         result[0] = null;
-        try {
-            instance.setAttachmentFormatters(result);
-            fail("Null index was allowed.");
-        } catch (NullPointerException NPE) {
-        } catch (RuntimeException re) {
-            fail(re.toString());
-        }
+        instance.setAttachmentFormatters(result);
+
+        result = instance.getAttachmentFormatters();
+        assertEquals(SimpleFormatter.class, result[0].getClass());
+        assertEquals(SimpleFormatter.class, result[1].getClass());
+
 
         result = new Formatter[0];
         try {
@@ -4188,48 +4347,30 @@ public class MailHandlerTest extends AbstractLogging {
         names = instance.getAttachmentNames();
         assertNotNull(names);
 
-        try {
-            instance.setAttachmentNames((String[]) null);
-            fail("Null was allowed.");
-        } catch (RuntimeException re) {
-            assertEquals(NullPointerException.class, re.getClass());
-        }
+        instance.setAttachmentNames((String[]) null);
+        assertEquals(0, instance.getAttachmentNames().length);
 
-        if (instance.getAttachmentFormatters().length > 0) {
-            instance.setAttachmentFormatters();
-        }
-
+        instance.setAttachmentFormatters();
         try {
             instance.setAttachmentNames(new String[0]);
         } catch (RuntimeException re) {
             fail(re.toString());
         }
 
-        try {
-            instance.setAttachmentNames(new String[1]);
-            fail("Mismatch with attachment formatters.");
-        } catch (NullPointerException | IndexOutOfBoundsException pass) {
-        } catch (RuntimeException re) {
-            fail(re.toString());
-        }
 
-        try {
-            instance.setAttachmentNames("foo.txt", "");
-            fail("Empty name was allowed.");
-        } catch (IllegalArgumentException pass) {
-        } catch (RuntimeException re) {
-            fail(re.toString());
-        }
+        instance.setAttachmentNames(new String[1]);
+        assertEquals(instance.getAttachmentFormatters().length, 1);
+        assertNotNull(instance.getAttachmentNames()[0]);
+
+
+        instance.setAttachmentNames("foo.txt", "");
+        assertFalse(instance.getAttachmentNames()[1].toString().isEmpty());
+
 
         instance.setAttachmentFormatters(
                 new SimpleFormatter(), new XMLFormatter());
-        try {
-            instance.setAttachmentNames(new String[2]);
-            fail("Null index was allowed.");
-        } catch (NullPointerException pass) {
-        } catch (RuntimeException re) {
-            fail(re.toString());
-        }
+
+        instance.setAttachmentNames(new String[2]);
 
         Formatter[] formatters = instance.getAttachmentFormatters();
         names = instance.getAttachmentNames();
@@ -4246,14 +4387,9 @@ public class MailHandlerTest extends AbstractLogging {
         assertEquals(stringNames[0].equals(
                 instance.getAttachmentNames()[0].toString()), false);
 
-        try {
-            instance.setAttachmentNames(new String[0]);
-            fail("Names mismatch formatters.");
-        } catch (IndexOutOfBoundsException pass) {
-        } catch (RuntimeException re) {
-            fail(re.toString());
-        }
 
+        instance.setAttachmentNames(new String[0]);
+        assertEquals(0, instance.getAttachmentNames().length);
         assertEquals(true, em.exceptions.isEmpty());
     }
 
@@ -4266,23 +4402,16 @@ public class MailHandlerTest extends AbstractLogging {
 
         assertNotNull(instance.getAttachmentNames());
 
-        try {
-            instance.setAttachmentNames((Formatter[]) null);
-            fail("Null was allowed.");
-        } catch (NullPointerException pass) {
-        } catch (RuntimeException re) {
-            fail(re.toString());
-        }
+
+        instance.setAttachmentNames((Formatter[]) null);
+        assertEquals(0, instance.getAttachmentNames().length);
+
 
         instance.setAttachmentFormatters();
+        instance.setAttachmentNames(new Formatter[2]);
+        assertEquals(2, instance.getAttachmentNames().length);
+        assertEquals(2, instance.getAttachmentFormatters().length);
 
-        try {
-            instance.setAttachmentNames(new Formatter[2]);
-            fail("formatter mismatch.");
-        } catch (NullPointerException | IndexOutOfBoundsException pass) {
-        } catch (RuntimeException re) {
-            fail(re.toString());
-        }
 
         instance.setAttachmentFormatters(
                 new SimpleFormatter(), new XMLFormatter());
@@ -4300,13 +4429,9 @@ public class MailHandlerTest extends AbstractLogging {
         assertEquals(em.exceptions.isEmpty(), true);
         instance.close();
 
-        try {
-            instance.setAttachmentNames(new Formatter[0]);
-            fail("formatter mismatch.");
-        } catch (NullPointerException | IndexOutOfBoundsException pass) {
-        } catch (RuntimeException re) {
-            fail(re.toString());
-        }
+
+        instance.setAttachmentNames(new Formatter[0]);
+        assertEquals(0, instance.getAttachmentFormatters().length);
     }
 
     @Test
@@ -4317,14 +4442,8 @@ public class MailHandlerTest extends AbstractLogging {
         instance.setErrorManager(em);
 
         assertNotNull(instance.getSubject());
-
-        try {
-            instance.setSubject((String) null);
-            fail("Null subject was allowed.");
-        } catch (NullPointerException pass) {
-        } catch (RuntimeException re) {
-            fail(re.toString());
-        }
+        instance.setSubject((String) null);
+        assertEquals(CollectorFormatter.class, instance.getSubject().getClass());
 
         instance.setSubject(subject);
         assertEquals(subject, instance.getSubject().toString());
@@ -4392,16 +4511,14 @@ public class MailHandlerTest extends AbstractLogging {
         InternalErrorManager em = new InternalErrorManager();
         instance.setErrorManager(em);
 
-        assertNotNull(instance.getSubject());
+        Formatter firstSubject = instance.getSubject();
+        assertNotNull(firstSubject);
         assertEquals(CollectorFormatter.class, instance.getSubject().getClass());
 
-        try {
-            instance.setSubject((Formatter) null);
-            fail("Null subject was allowed.");
-        } catch (NullPointerException pass) {
-        } catch (RuntimeException re) {
-            fail(re.toString());
-        }
+        instance.setSubject((Formatter) null);
+
+        assertEquals(CollectorFormatter.class, instance.getSubject().getClass());
+        assertNotSame(firstSubject, instance.getSubject());
 
         instance.setSubject(format);
         assertEquals(format, instance.getSubject());
@@ -6477,17 +6594,15 @@ public class MailHandlerTest extends AbstractLogging {
             target = new MailHandler();
             try {
                 em = internalErrorManagerFrom(target);
-                for (Exception exception : em.exceptions) {
-                    if (!(exception instanceof NullPointerException)) {
-                        dump(exception);
-                    }
-                }
                 assertEquals(1, target.getAttachmentFormatters().length);
                 assertEquals(SimpleFormatter.class, target.getAttachmentFormatters()[0].getClass());
                 assertEquals(1, target.getAttachmentNames().length);
                 String name = target.getAttachmentNames()[0].toString();
                 assertTrue(name, name.contains(SimpleFormatter.class.getName()));
-                assertEquals(2, em.exceptions.size());
+                for (Exception exception : em.exceptions) {
+                    dump(exception);
+                }
+                assertEquals(0, em.exceptions.size());
             } finally {
                 target.close();
             }


### PR DESCRIPTION
This is the PR for [WildFly support for MailHandler ](https://github.com/eclipse-ee4j/angus-mail/issues/110)

The key takeaways from this patch are:

1. A new bean style adapter methods were added to parse mail properties file from a string.  This allows the MailHandler to not be tied to a specific type of transport.
2. Existing public methods needed to be relaxed to handle properties being cleared with 0 or null.
3. Parts of WildFly get confused by method overloading.  New method names have been added to provide a unique namespace.  There is really no need to deprecated the old methods as I don't see a need to ever remove them.
4. WildFly uses printf style formatting in its log messages.  This revealed a long standing bug in the CompactFormatter and required an enhancement to the CompactFormatter in order to render the subject of an email correctly.
5. A future enhancement ticket will be created to deal with Comparator creation.  It is not supported in this patch.
6. MailHandler has been updated to fix issues with attachments but attachments are not support because WildFly doesn't understand array method parameters.  I'll file an enhancement request against WildFly for this before exploring any alternative options in the MailHandler.
7. There are references to JavaMail API in the MailHandler.  I'm going to create a new ticket to deal with those.